### PR TITLE
NAS-136464 / 25.10 / Optionally handle wildcard domain creation for ACME challenge

### DIFF
--- a/truenas_connect_utils/hostname.py
+++ b/truenas_connect_utils/hostname.py
@@ -36,7 +36,10 @@ async def hostname_config(tnc_config: dict) -> dict:
 
 
 async def register_update_ips(tnc_config: dict, ips: list[str], create_wildcard: bool) -> dict:
-    logger.debug('Updating TNC hostname configuration with %r ips', ','.join(ips))
+    logger.debug(
+        'Updating TNC hostname configuration with %r ips and with create_wildcard %r value',
+        ','.join(ips), create_wildcard
+    )
     config = await hostname_config(tnc_config)
     if config['error']:
         raise CallError(f'Failed to fetch TNC hostname configuration: {config["error"]}')

--- a/truenas_connect_utils/hostname.py
+++ b/truenas_connect_utils/hostname.py
@@ -35,7 +35,7 @@ async def hostname_config(tnc_config: dict) -> dict:
     }
 
 
-async def register_update_ips(tnc_config: dict, ips: list[str]) -> dict:
+async def register_update_ips(tnc_config: dict, ips: list[str], create_wildcard: bool) -> dict:
     logger.debug('Updating TNC hostname configuration with %r ips', ','.join(ips))
     config = await hostname_config(tnc_config)
     if config['error']:
@@ -43,6 +43,6 @@ async def register_update_ips(tnc_config: dict, ips: list[str]) -> dict:
 
     creds = get_account_id_and_system_id(tnc_config)
     return await call(
-        get_hostname_url(tnc_config).format(**creds), 'put', payload={'ips': ips},
+        get_hostname_url(tnc_config).format(**creds), 'put', payload={'ips': ips, 'create_wildcards': create_wildcard},
         tnc_config=tnc_config, include_auth=True,
     )

--- a/truenas_connect_utils/tnc_authenticator.py
+++ b/truenas_connect_utils/tnc_authenticator.py
@@ -69,7 +69,8 @@ class TrueNASConnectAuthenticator:
             requests.delete(
                 get_leca_cleanup_url(self.tnc_config), headers=auth_headers(self.tnc_config),
                 timeout=30, data=json.dumps({
-                    'hostnames': [validation_name],  # We use validation name here instead of domain as Zack advised
+                    'hostnames': [validation_name, f'*.{domain}'],
+                    # We would like to pass in domain here as well to remove the wildcard record
                 })
             )
         except Exception:


### PR DESCRIPTION
This PR adds changes to make sure that we only create wildcard domain for the cert and after ACME challenge is completed, we have it removed.