### PR TITLE
NAS-137949 / 25.10.0 / Fix baesdomain parsing logic (by sonicaj)

### DIFF
--- a/truenas_connect_utils/hostname.py
+++ b/truenas_connect_utils/hostname.py
@@ -25,7 +25,7 @@ async def hostname_config(tnc_config: dict) -> dict:
     )) | {'base_domain': None}
     resp['hostname_details'] = resp.pop('response')
     for domain in resp['hostname_details']:
-        if len(domain.rsplit('.', maxsplit=4)) == 5 and domain.startswith('*.'):
+        if len(domain.rsplit('.', maxsplit=4)) == 5:
             resp['base_domain'] = domain.split('.', maxsplit=1)[-1]
             break
 


### PR DESCRIPTION
This commit adds changes to make sure we parse out base domain even if we are not getting a record with wildcard entry from TNC side.

Original PR: https://github.com/truenas/truenas_connect_utils/pull/16
