### PR TITLE
NAS-139580 / 26.0.0-BETA.1 / Fix JSON serialization error for response headers

### DIFF
--- a/truenas_connect_utils/request.py
+++ b/truenas_connect_utils/request.py
@@ -52,7 +52,7 @@ async def call(
     except aiohttp.ClientConnectorError as e:
         response['error'] = f'Failed to connect to TNC: {e}'
     else:
-        response['headers'] = req.headers
+        response['headers'] = dict(req.headers)
         if get_response:
             response['response'] = await req.json() if json_response else await req.text()
     return response


### PR DESCRIPTION
This commit fixes a regression introduced in 780b7da where response headers were stored as a CIMultiDictProxy object which is not JSON serializable. The fix converts headers to a plain dict.