### PR TITLE
NAS-139736 / 26.0.0-BETA.1 / Fix urljoin bug in get_hostname_url dropping system_id path segment

### DIFF
--- a/truenas_connect_utils/urls.py
+++ b/truenas_connect_utils/urls.py
@@ -10,7 +10,7 @@ def get_account_service_url(tnc_config: dict) -> str:
 
 
 def get_hostname_url(tnc_config: dict) -> str:
-    return urllib.parse.urljoin(get_account_service_url(tnc_config), 'hostnames/')
+    return urllib.parse.urljoin(get_account_service_url(tnc_config) + '/', 'hostnames/')
 
 
 def get_leca_dns_url(tnc_config: dict) -> str:


### PR DESCRIPTION
This commit fixes a regression by fa56f893b841b27ff3ba87d17f9655cb7712e43e where now silently system id gets dropped.