### PR TITLE
NAS-140159 / 27.0.0-BETA.1 / Log order url in case of failure

### DIFF
--- a/truenas_connect_utils/acme.py
+++ b/truenas_connect_utils/acme.py
@@ -120,10 +120,20 @@ async def create_cert(
         csr, private_key = csr_details['csr'], csr_details['private_key']
 
     authenticator_mapping = {f'DNS:{hostname}': TrueNASConnectAuthenticator(tnc_config) for hostname in hostnames}
-    logger.debug('Performing ACME challenge for TNC certificate')
-    final_order = await asyncio.to_thread(
-        issue_certificate, tnc_acme_config['acme_details'], csr, authenticator_mapping, 25, cert_renewal_id,
+    logger.debug(
+        'Initiating ACME order for hostnames: %s (directory: %s)',
+        hostnames, tnc_acme_config['acme_details']['directory'],
     )
+    try:
+        final_order = await asyncio.to_thread(
+            issue_certificate, tnc_acme_config['acme_details'], csr, authenticator_mapping, 25, cert_renewal_id,
+        )
+    except Exception as e:
+        extra = getattr(e, 'extra', None)
+        if isinstance(extra, dict) and extra.get('order_uri'):
+            logger.debug('ACME order failed, order URL: %s', extra['order_uri'])
+        raise
+    logger.debug('ACME order completed successfully, order URL: %s', final_order.uri)
     return {
         'cert': final_order.fullchain_pem,
         'acme_uri': final_order.uri,

--- a/truenas_connect_utils/tnc_authenticator.py
+++ b/truenas_connect_utils/tnc_authenticator.py
@@ -44,8 +44,8 @@ class TrueNASConnectAuthenticator:
 
     def _perform_internal(self, domain, validation_name, validation_content):
         logger.debug(
-            'Performing %r challenge for %r domain with %r validation name and %r validation content',
-            self.NAME, domain, validation_name, validation_content,
+            'Performing %r challenge for %r domain (endpoint: %s) with %r validation name and %r validation content',
+            self.NAME, domain, get_leca_dns_url(self.tnc_config), validation_name, validation_content,
         )
         try:
             response = requests.post(get_leca_dns_url(self.tnc_config), data=json.dumps({
@@ -61,10 +61,16 @@ class TrueNASConnectAuthenticator:
                 f'{response.status_code!r} status code: {response.text}'
             )
 
-        logger.debug('Successfully performed %r challenge for %r domain', self.NAME, domain)
+        logger.debug(
+            'Successfully performed %r challenge for %r domain (status: %d)',
+            self.NAME, domain, response.status_code,
+        )
 
     def _cleanup(self, domain, validation_name, validation_content):
-        logger.debug('Cleaning up %r challenge for %r domain', self.NAME, domain)
+        logger.debug(
+            'Cleaning up %r challenge for %r domain (endpoint: %s)',
+            self.NAME, domain, get_leca_cleanup_url(self.tnc_config),
+        )
         try:
             requests.delete(
                 get_leca_cleanup_url(self.tnc_config), headers=auth_headers(self.tnc_config),


### PR DESCRIPTION
This commit adds changes so if while trying to get cert issued for TNC and that step failing for some reason, we at least try to log the order url so this can be chased with the provider or at least we have more insight on what might have happened.