### PR TITLE
NAS-140877 / 27.0.0-BETA.1 / Increase default TNC HTTP request timeout to 55s

### DIFF
--- a/truenas_connect_utils/request.py
+++ b/truenas_connect_utils/request.py
@@ -19,7 +19,7 @@ async def call(
     tnc_config: dict[str, Any] | None = None, include_auth: bool = False,
 ) -> dict[str, Any]:
     options = options or {}
-    timeout = options.get('timeout', 15)
+    timeout = options.get('timeout', 55)
     response: dict[str, Any] = {
         'error': None,
         'response': {},


### PR DESCRIPTION
This commit raises the default request timeout in the shared TNC HTTP helper from 15 to 55 seconds because calls to TNC's account service (notably GET /v1/accounts/<id>/acme) can transiently take longer when the upstream ZeroSSL provider experiences brief outages. TNC already performs its own internal retries to ride out such outages, but those retries are bounded by the 60s per-request cap enforced by the k8s ingress/gateway in front of the TNC service. The previous 15s client-side timeout caused the NAS to give up before TNC's own retry window could complete, surfacing as  and prematurely forcing a fallback to Let's Encrypt.

Bumping the default to 55s aligns the middleware-side timeout with TNC's server-side cap (with a small margin for client lifecycle overhead), so the NAS waits long enough for TNC's retries to absorb short ZeroSSL blips. All TNC-bound call sites (acme config, hostname register/update, registration finalization, heartbeat, account unset) rely on this default, so a single change covers them uniformly.