### PR TITLE
NAS-140333 / 27.0.0-BETA.1 / Stop polling on terminal TNC finalize errors

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Set up Python
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # Step 3: Install dependencies
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+
+      # Step 4: Add project root to PYTHONPATH
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      # Step 5: Run tests with pytest
+      - name: Run tests
+        run: |
+          pytest -v --disable-pytest-warnings pytest/unit

--- a/pytest/unit/test_finalize_classifier.py
+++ b/pytest/unit/test_finalize_classifier.py
@@ -1,0 +1,91 @@
+import pytest
+
+from truenas_connect_utils.finalize import FinalizeResult, classify_finalize_response
+
+
+def make_resp(*, status_code=None, response=None, error=None, headers=None):
+    return {
+        'status_code': status_code,
+        'response': response if response is not None else {},
+        'error': error,
+        'headers': headers or {},
+    }
+
+
+@pytest.mark.parametrize('status_code', [200, 201, 204])
+def test_2xx_with_token_is_success(status_code):
+    result, _ = classify_finalize_response(make_resp(status_code=status_code, response={'token': 'abc'}))
+    assert result is FinalizeResult.SUCCESS
+
+
+def test_2xx_without_token_is_terminal():
+    result, description = classify_finalize_response(make_resp(status_code=200, response={}))
+    assert result is FinalizeResult.TERMINAL
+    assert 'token missing' in description
+
+
+def test_2xx_with_non_dict_body_is_terminal():
+    result, _ = classify_finalize_response(make_resp(status_code=200, response='plain text'))
+    assert result is FinalizeResult.TERMINAL
+
+
+def test_400_with_not_found_retries():
+    body = {'error': 'not found', 'data': {'entity': 'system', 'id': 'abc-123'}}
+    result, description = classify_finalize_response(make_resp(status_code=400, response=body))
+    assert result is FinalizeResult.RETRY
+    assert 'pending registration' in description
+
+
+def test_400_with_different_error_string_is_terminal():
+    result, _ = classify_finalize_response(
+        make_resp(status_code=400, response={'error': 'invalid claim token'})
+    )
+    assert result is FinalizeResult.TERMINAL
+
+
+def test_400_case_sensitive_match():
+    result, _ = classify_finalize_response(
+        make_resp(status_code=400, response={'error': 'NOT FOUND'})
+    )
+    assert result is FinalizeResult.TERMINAL
+
+
+def test_400_with_non_dict_body_is_terminal():
+    result, _ = classify_finalize_response(make_resp(status_code=400, response='Bad Request'))
+    assert result is FinalizeResult.TERMINAL
+
+
+@pytest.mark.parametrize('status_code', [401, 403, 404, 405, 422])
+def test_other_4xx_is_terminal(status_code):
+    result, _ = classify_finalize_response(
+        make_resp(status_code=status_code, response={'error': 'whatever'})
+    )
+    assert result is FinalizeResult.TERMINAL
+
+
+@pytest.mark.parametrize('status_code', [408, 429])
+def test_transient_status_retries(status_code):
+    result, _ = classify_finalize_response(make_resp(status_code=status_code, response={}))
+    assert result is FinalizeResult.RETRY
+
+
+@pytest.mark.parametrize('status_code', [500, 502, 503, 504])
+def test_5xx_retries(status_code):
+    result, _ = classify_finalize_response(
+        make_resp(status_code=status_code, response={'error': 'down'})
+    )
+    assert result is FinalizeResult.RETRY
+
+
+def test_status_code_none_with_error_retries():
+    result, description = classify_finalize_response(
+        make_resp(status_code=None, error='Unable to connect with TNC in 55 seconds.')
+    )
+    assert result is FinalizeResult.RETRY
+    assert 'Unable to connect' in description
+
+
+def test_status_code_none_no_error_field_still_retries():
+    result, description = classify_finalize_response(make_resp(status_code=None))
+    assert result is FinalizeResult.RETRY
+    assert description == 'connection error'

--- a/pytest/unit/test_finalize_classifier.py
+++ b/pytest/unit/test_finalize_classifier.py
@@ -55,6 +55,17 @@ def test_400_with_non_dict_body_is_terminal():
     assert result is FinalizeResult.TERMINAL
 
 
+@pytest.mark.parametrize('error_value', [['not found'], {'msg': 'not found'}, None, 42])
+def test_400_with_non_string_error_field_is_terminal(error_value):
+    # Hardening: guard against malformed bodies where `error` is not a string.
+    # Without an isinstance check, `body.get('error') in frozenset({...})` raises
+    # TypeError when the value is unhashable (list/dict).
+    result, _ = classify_finalize_response(
+        make_resp(status_code=400, response={'error': error_value})
+    )
+    assert result is FinalizeResult.TERMINAL
+
+
 @pytest.mark.parametrize('status_code', [401, 403, 404, 405, 422])
 def test_other_4xx_is_terminal(status_code):
     result, _ = classify_finalize_response(
@@ -89,3 +100,13 @@ def test_status_code_none_no_error_field_still_retries():
     result, description = classify_finalize_response(make_resp(status_code=None))
     assert result is FinalizeResult.RETRY
     assert description == 'connection error'
+
+
+def test_2xx_with_empty_dict_response_is_terminal():
+    # After json_response=True parse failure, request.call() returns response={}
+    # with error set. Classifier should treat 2xx + missing token as TERMINAL.
+    result, description = classify_finalize_response(
+        make_resp(status_code=200, response={}, error="HTTP 200: expected JSON, got Content-Type 'text/html'")
+    )
+    assert result is FinalizeResult.TERMINAL
+    assert 'token missing' in description

--- a/truenas_connect_utils/finalize.py
+++ b/truenas_connect_utils/finalize.py
@@ -1,0 +1,51 @@
+import enum
+from typing import Any
+
+
+class FinalizeResult(enum.Enum):
+    SUCCESS = 'success'
+    RETRY = 'retry'
+    TERMINAL = 'terminal'
+
+
+RETRYABLE_STATUS_CODES = frozenset({408, 429})
+RETRYABLE_400_ERROR_STRINGS = frozenset({'not found'})
+
+
+def classify_finalize_response(resp: dict[str, Any]) -> tuple[FinalizeResult, str]:
+    """Classify a /v1/systems/finalize response dict from request.call().
+
+    Decision matrix:
+      - 2xx with 'token' in body              -> SUCCESS
+      - 2xx without 'token'                   -> TERMINAL
+      - status_code is None                   -> RETRY (network failure)
+      - 5xx                                   -> RETRY
+      - 408, 429                              -> RETRY
+      - 400 with body['error'] == 'not found' -> RETRY (user has not yet
+                                                 completed UI registration)
+      - any other non-2xx                     -> TERMINAL
+
+    Returns (result, description). `description` is a short human-readable
+    string suitable for logging or storing in an initialization_error field.
+    """
+    status = resp.get('status_code')
+    body = resp.get('response') or {}
+
+    if status is None:
+        return FinalizeResult.RETRY, resp.get('error') or 'connection error'
+
+    if 200 <= status < 300:
+        if isinstance(body, dict) and 'token' in body:
+            return FinalizeResult.SUCCESS, ''
+        return FinalizeResult.TERMINAL, f'token missing from successful response: {body!r}'
+
+    if 500 <= status < 600:
+        return FinalizeResult.RETRY, f'TNC {status}: {body!r}'
+
+    if status in RETRYABLE_STATUS_CODES:
+        return FinalizeResult.RETRY, f'TNC {status}: {body!r}'
+
+    if status == 400 and isinstance(body, dict) and body.get('error') in RETRYABLE_400_ERROR_STRINGS:
+        return FinalizeResult.RETRY, f'TNC pending registration: {body!r}'
+
+    return FinalizeResult.TERMINAL, f'TNC {status}: {body!r}'

--- a/truenas_connect_utils/finalize.py
+++ b/truenas_connect_utils/finalize.py
@@ -45,7 +45,10 @@ def classify_finalize_response(resp: dict[str, Any]) -> tuple[FinalizeResult, st
     if status in RETRYABLE_STATUS_CODES:
         return FinalizeResult.RETRY, f'TNC {status}: {body!r}'
 
-    if status == 400 and isinstance(body, dict) and body.get('error') in RETRYABLE_400_ERROR_STRINGS:
+    if (
+        status == 400 and isinstance(body, dict) and isinstance(body.get('error'), str)
+        and body['error'] in RETRYABLE_400_ERROR_STRINGS
+    ):
         return FinalizeResult.RETRY, f'TNC pending registration: {body!r}'
 
     return FinalizeResult.TERMINAL, f'TNC {status}: {body!r}'

--- a/truenas_connect_utils/request.py
+++ b/truenas_connect_utils/request.py
@@ -39,25 +39,36 @@ async def call(
 
     try:
         async with asyncio.timeout(timeout):
-            async with aiohttp.ClientSession(raise_for_status=True, trust_env=True) as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 session_method: Callable[..., Any] = getattr(session, mode)
                 req = await session_method(
                     endpoint,
                     data=json.dumps(payload) if payload is not None else payload,
                     headers=headers,
                 )
-                response['status_code'] = req.status
+                # Capture locally first; only commit to `response` after the body
+                # is fully read. If the timeout fires mid-body, status_code stays
+                # None so callers see a transport failure (RETRY) rather than a
+                # bogus 2xx with empty body (which would otherwise classify as
+                # TERMINAL "token missing").
+                status = req.status
+                resp_headers = {k.title(): v for k, v in req.headers.items()}
+                body: Any = {}
+                if get_response:
+                    if json_response:
+                        try:
+                            body = await req.json()
+                        except (aiohttp.ContentTypeError, ValueError):
+                            body = await req.text()
+                    else:
+                        body = await req.text()
+                response['status_code'] = status
+                response['headers'] = resp_headers
+                response['response'] = body
+                if status >= 400:
+                    response['error'] = f'HTTP {status}: {body!r}'
     except asyncio.TimeoutError:
         response['error'] = f'Unable to connect with TNC in {timeout} seconds.'
-    except aiohttp.ClientResponseError as e:
-        response.update({
-            'error': str(e),
-            'status_code': e.status,
-        })
     except aiohttp.ClientConnectorError as e:
         response['error'] = f'Failed to connect to TNC: {e}'
-    else:
-        response['headers'] = {k.title(): v for k, v in req.headers.items()}
-        if get_response:
-            response['response'] = await req.json() if json_response else await req.text()
     return response

--- a/truenas_connect_utils/request.py
+++ b/truenas_connect_utils/request.py
@@ -54,19 +54,28 @@ async def call(
                 status = req.status
                 resp_headers = {k.title(): v for k, v in req.headers.items()}
                 body: Any = {}
+                parse_error: str | None = None
                 if get_response:
                     if json_response:
                         try:
                             body = await req.json()
                         except (aiohttp.ContentTypeError, ValueError):
-                            body = await req.text()
+                            raw = await req.text()
+                            content_type = req.headers.get('Content-Type', '<missing>')
+                            parse_error = (
+                                f'expected JSON, got Content-Type {content_type!r}, body={raw[:500]!r}'
+                            )
+                            body = {}
                     else:
                         body = await req.text()
                 response['status_code'] = status
                 response['headers'] = resp_headers
                 response['response'] = body
                 if status >= 400:
-                    response['error'] = f'HTTP {status}: {body!r}'
+                    detail = parse_error if parse_error is not None else repr(body)
+                    response['error'] = f'HTTP {status}: {detail}'
+                elif parse_error is not None:
+                    response['error'] = f'HTTP {status}: {parse_error}'
     except asyncio.TimeoutError:
         response['error'] = f'Unable to connect with TNC in {timeout} seconds.'
     except aiohttp.ClientConnectorError as e:


### PR DESCRIPTION
This commit disables aiohttp's raise_for_status so non-2xx response bodies are preserved for the caller, and adds a shared classifier that decides whether a /v1/systems/finalize response should be retried or treated as terminal. Status code is only committed after the body is fully read so a slow body read no longer looks like a successful empty response. 400 with "not found" and 5xx/408/429 remain retryable; everything else non-2xx is terminal.