### PR TITLE
NAS-141101 / 27.0.0-BETA.1 / Remove trailing slash from TNC hostnames endpoint URL

### DIFF
--- a/truenas_connect_utils/urls.py
+++ b/truenas_connect_utils/urls.py
@@ -13,7 +13,7 @@ def get_account_service_url(tnc_config: dict[str, Any]) -> str:
 
 
 def get_hostname_url(tnc_config: dict[str, Any]) -> str:
-    return urllib.parse.urljoin(get_account_service_url(tnc_config) + '/', 'hostnames/')
+    return urllib.parse.urljoin(get_account_service_url(tnc_config) + '/', 'hostnames')
 
 
 def get_leca_dns_url(tnc_config: dict[str, Any]) -> str:


### PR DESCRIPTION
This commit fixes an issue where get_hostname_url still produced a trailing slash on /accounts/:id/systems/:id/hostnames/, causing every GET/PUT to redirect on the TNC backend and incur an extra round-trip. The earlier attempt only dropped the slash from get_account_service_url, so the hostnames path was left untouched; we keep the '/' appended to that base URL to avoid urljoin dropping the system_id segment.